### PR TITLE
Swagger page fix

### DIFF
--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -58,6 +58,7 @@ def create_app():
         version="1.0",
         title="Biomarker APIs",
         description="Biomarker APIs",
+        specs_url="/biomarker/api/swagger.json",
         openapi="3.0.0",
     )
 

--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -58,7 +58,7 @@ def create_app():
         version="1.0",
         title="Biomarker APIs",
         description="Biomarker APIs",
-        openapi="3.0.2",
+        openapi="3.0.0",
     )
 
     api.add_namespace(biomarker_api)

--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -11,6 +11,7 @@ from .backend_utils import CustomFlask
 from .backend_utils.performance_logger import PerformanceLogger
 from .biomarker import api as biomarker_api
 from .auth import api as auth_api
+from .swagger import api as swagger_api
 
 MONGO_URI = os.getenv("MONGODB_CONNSTRING")
 DB_NAME = "biomarkerdb_api"
@@ -59,10 +60,10 @@ def create_app():
         title="Biomarker APIs",
         description="Biomarker APIs",
         specs_url="/biomarker/api/swagger.json",
-        openapi="3.0.0",
     )
 
     api.add_namespace(biomarker_api)
     api.add_namespace(auth_api)
+    api.add_namespace(swagger_api)
 
     return app

--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -57,7 +57,8 @@ def create_app():
         app,
         version="1.0",
         title="Biomarker APIs",
-        description="Biomarker Knowledgebase API",
+        description="Biomarker APIs",
+        openapi="3.0.2",
     )
 
     api.add_namespace(biomarker_api)

--- a/api/biomarker/swagger.py
+++ b/api/biomarker/swagger.py
@@ -1,0 +1,28 @@
+"""Hacks the swagger.json base_url. This is a temporary placeholder while
+the biomarker-partnership is hosted on the hivelab server. Once a dedicated
+server is opened up this will be removed.
+"""
+
+from flask_restx import Resource, Namespace  # type: ignore
+import requests
+
+api = Namespace("swagger", description="Swagger JSON namespace.")
+
+
+class SwaggerFix(Resource):
+
+    def get(self):
+
+        swagger_url = "https://hivelab.biochemistry.gwu.edu/biomarker/api/swagger.json"
+
+        swagger_response = requests.get(swagger_url)
+        if swagger_response.status_code != 200:
+            return {"error": "error-retrieving-swagger-json"}, 500
+
+        swagger_json = swagger_response.json()
+        swagger_json["basePath"] = "/biomarker/api"
+
+        return swagger_json, 200
+
+
+api.add_resource(SwaggerFix, "/")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ werkzeug==3.0.1
 user-agents==2.2.0
 cachetools==5.3.3
 python-dotenv==1.0.1
+requests==2.32.3


### PR DESCRIPTION
Very hack-y fix to get the swagger pages up and running. This is a temporary solution until the biomarker project gets its own domain/server. There are issues with Flask-restx when not serving the project at the root. 