### PR TITLE
Swagger hack

### DIFF
--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -11,6 +11,7 @@ from .backend_utils import CustomFlask
 from .backend_utils.performance_logger import PerformanceLogger
 from .biomarker import api as biomarker_api
 from .auth import api as auth_api
+from .swagger import api as swagger_api
 
 MONGO_URI = os.getenv("MONGODB_CONNSTRING")
 DB_NAME = "biomarkerdb_api"
@@ -62,5 +63,6 @@ def create_app():
 
     api.add_namespace(biomarker_api)
     api.add_namespace(auth_api)
+    api.add_namespace(swagger_api)
 
     return app

--- a/api/biomarker/auth.py
+++ b/api/biomarker/auth.py
@@ -6,7 +6,7 @@ api = Namespace("auth", description="Authentication API namespace.")
 
 class Contact(Resource):
 
-    @api.doc("contact")
+    @api.doc(False)
     def post(self):
         return auth_utils.contact(request)
     

--- a/api/biomarker/auth.py
+++ b/api/biomarker/auth.py
@@ -2,7 +2,7 @@ from flask import request
 from flask_restx import Resource, Namespace  # type: ignore
 from .backend_utils import auth_utils as auth_utils
 
-api = Namespace("auth", description="Authentication API namespace.")
+api = Namespace("auth", description="Authentication API namespace.", hide=True)
 
 class Contact(Resource):
 
@@ -10,6 +10,7 @@ class Contact(Resource):
     def post(self):
         return auth_utils.contact(request)
     
+    @api.doc(False)
     def get(self):
         return self.post()
 

--- a/api/biomarker/biomarker.py
+++ b/api/biomarker/biomarker.py
@@ -1,5 +1,5 @@
 from flask import request
-from flask_restx import Resource, Namespace  # type: ignore
+from flask_restx import Resource, Namespace, fields  # type: ignore
 from .backend_utils import detail_utils as detail_utils
 from .backend_utils import list_utils as list_utils
 from .backend_utils import search_utils as search_utils
@@ -29,12 +29,23 @@ class SearchInit(Resource):
         return self.post()
 
 
+search_simple_model = api.model(
+    "Biomarker Simple Search Query",
+    {
+        "term_category": fields.String(required=True, default="biomarker"),
+        "term": fields.String(required=True, default="AA4686-1"),
+    },
+)
+
+
 class SearchSimple(Resource):
 
     @api.doc("search_simple")
+    @api.expect(search_simple_model, validate=False)
     def post(self):
         return search_utils.simple_search(request)
 
+    @api.doc(False)
     def get(self):
         return self.post()
 

--- a/api/biomarker/biomarker.py
+++ b/api/biomarker/biomarker.py
@@ -50,22 +50,51 @@ class SearchSimple(Resource):
         return self.post()
 
 
+full_search_model = api.model(
+    "Biomarker Search Query",
+    {
+        "biomarker_id": fields.String(required=True, default="AA4686-1"),
+        "biomarker": fields.String(required=True, default="increased IL6 level"),
+        "biomarker_entity_name": fields.String(required=True, default="Interleukin-6"),
+        "biomarker_entity_id": fields.String(required=True, default="P05231-1"),
+        "biomarker_entity_type": fields.String(required=True, default="protein"),
+        "specimen_name": fields.String(required=True, default="blood"),
+        "specimen_id": fields.String(required=True, default="0000178"),
+        "specimen_loinc_code": fields.String(required=True, default="26881-3"),
+        "best_biomarker_role": fields.String(required=True, default="prognostic"),
+        "condition_id": fields.String(required=True, default="DOID:10283"),
+        "condition_name": fields.String(required=True, default="prostate cancer"),
+        "publication_id": fields.String(required=True, default="10914713"),
+    },
+)
+
+
 class FullSearch(Resource):
 
     @api.doc("search")
+    @api.expect(full_search_model, validate=False)
     def post(self):
         return search_utils.full_search(request)
 
+    @api.doc(False)
     def get(self):
         return self.post()
+
+
+list_model = api.model(
+    "List Query",
+    {"id": fields.String(required=True, default="3def43533cf6434b633cd18d1a7da5b2")},
+)
 
 
 class List(Resource):
 
     @api.doc("list")
+    @api.expect(list_model, validate=False)
     def post(self):
         return list_utils.list(request)
 
+    @api.doc(False)
     def get(self):
         return self.post()
 

--- a/api/biomarker/biomarker.py
+++ b/api/biomarker/biomarker.py
@@ -9,20 +9,22 @@ api = Namespace("biomarker", description="Biomarker API namespace.")
 
 class Detail(Resource):
 
-    @api.doc("detail")
+    @api.doc(False)
     def post(self, biomarker_id):
         return detail_utils.detail(request, biomarker_id)
 
+    @api.doc("detail")
     def get(self, biomarker_id):
         return self.post(biomarker_id)
 
 
 class SearchInit(Resource):
 
-    @api.doc("search_init")
+    @api.doc(False)
     def post(self):
         return search_utils.init()
 
+    @api.doc("search_init")
     def get(self):
         return self.post()
 

--- a/api/biomarker/swagger.py
+++ b/api/biomarker/swagger.py
@@ -1,7 +1,7 @@
 from flask_restx import Resource, Namespace  # type: ignore
 import requests
 
-api = Namespace("swagger", description="Temporary swagger hack.")
+api = Namespace("swagger", description="Temporary swagger hack.", hide=True)
 
 swagger_url = "https://hivelab.tst.biochemistry.gwu.edu/biomarker/api/swagger.json"
 

--- a/api/biomarker/swagger.py
+++ b/api/biomarker/swagger.py
@@ -1,7 +1,7 @@
 from flask_restx import Resource, Namespace  # type: ignore
 import requests
 
-api = Namespace("swagger", description="Temporary swagger hack.", hide=True)
+api = Namespace("swagger", description="Swagger endpoints.", hide=True)
 
 swagger_url = "https://hivelab.tst.biochemistry.gwu.edu/biomarker/api/swagger.json"
 

--- a/api/biomarker/swagger.py
+++ b/api/biomarker/swagger.py
@@ -7,6 +7,7 @@ swagger_url = "https://hivelab.tst.biochemistry.gwu.edu/biomarker/api/swagger.js
 
 class SwaggerHack(Resource):
 
+    @api.doc(False)
     def get(self):
         
         swagger_response = requests.get(swagger_url)

--- a/api/biomarker/swagger.py
+++ b/api/biomarker/swagger.py
@@ -1,0 +1,23 @@
+from flask_restx import Resource, Namespace  # type: ignore
+import requests
+
+api = Namespace("swagger", description="Temporary swagger hack.")
+
+swagger_url = "https://hivelab.tst.biochemistry.gwu.edu/biomarker/api/swagger.json"
+
+class SwaggerHack(Resource):
+
+    def get(self):
+        
+        swagger_response = requests.get(swagger_url)
+
+        if swagger_response.status_code != 200:
+
+            return {"error": "error-retrieving-swagger-json"}, 500
+
+        swagger_json = swagger_response.json()
+        swagger_json["basePath"] = "/biomarker/api"
+
+        return swagger_json, 200
+
+api.add_resource(SwaggerHack, "/")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,3 +11,4 @@ werkzeug==3.0.1
 user-agents==2.2.0
 cachetools==5.3.3
 python-dotenv==1.0.1
+requests==2.32.3


### PR DESCRIPTION
Pretty hack-y workaround to getting the swagger pages served from behind the reverse proxy. Once the biomarker project gets its own servers this won't be needed, but for now this works. 