### PR TITLE
Revert custom middleware

### DIFF
--- a/api/biomarker/__init__.py
+++ b/api/biomarker/__init__.py
@@ -21,16 +21,16 @@ MONGO_URI = os.getenv("MONGODB_CONNSTRING")
 DB_NAME = "biomarkerdb_api"
 
 
-class CustomApi(Api):
-    def _register_specs(self, app_or_blueprint):
-        pass
-
-    @property
-    def __schema__(self):
-        # Override the __schema__ property if you need to modify the schema
-        schema = super().__schema__.copy()
-        schema["basePath"] = "/api"  # Set the basePath here
-        return schema
+# class CustomApi(Api):
+#     def _register_specs(self, app_or_blueprint):
+#         pass
+#
+#     @property
+#     def __schema__(self):
+#         # Override the __schema__ property if you need to modify the schema
+#         schema = super().__schema__.copy()
+#         schema["basePath"] = "/api"  # Set the basePath here
+#         return schema
 
 
 def setup_logging() -> Logger:
@@ -89,32 +89,32 @@ def create_app():
     mongo_db = mongo_client[DB_NAME]
     app.mongo_db = mongo_db
 
-    @apidoc.apidoc.add_app_template_global
-    def swagger_static(filename):
-        return f"./api/swaggerui/{filename}"
+    # @apidoc.apidoc.add_app_template_global
+    # def swagger_static(filename):
+    #     return f"./api/swaggerui/{filename}"
 
     # setup the api using the flask_restx library
-    api = CustomApi(
+    api = Api(
         app,
         version="1.0",
         title="Biomarker APIs",
         description="Biomarker Knowledgebase API",
     )
 
-    @api.route("/swagger.json")
-    class SwaggerJson(Resource):
-        def get(self):
-            swagger_spec = api.__schema__.copy()
-            app.logger.info(f"swagger spec copy: {swagger_spec}")
-            swagger_spec["basePath"] = "/api"
-            app.logger.info(f"after swagger spec copy: {swagger_spec}")
-            return swagger_spec
-
-    @api.documentation
-    def custom_ui():
-        return render_template(
-            "swagger-ui.html", title=api.title, specs_url="./api/swagger.json"
-        )
+    # @api.route("/swagger.json")
+    # class SwaggerJson(Resource):
+    #     def get(self):
+    #         swagger_spec = api.__schema__.copy()
+    #         app.logger.info(f"swagger spec copy: {swagger_spec}")
+    #         swagger_spec["basePath"] = "/api"
+    #         app.logger.info(f"after swagger spec copy: {swagger_spec}")
+    #         return swagger_spec
+    #
+    # @api.documentation
+    # def custom_ui():
+    #     return render_template(
+    #         "swagger-ui.html", title=api.title, specs_url="./api/swagger.json"
+    #     )
 
     api.add_namespace(biomarker_api)
     api.add_namespace(auth_api)


### PR DESCRIPTION
Now that the API is hosted at its own domain name removing the middleware for serving swagger documentation. 